### PR TITLE
chore: update typst.toml repo URL and bump patch to 0.2.1

### DIFF
--- a/typst.toml
+++ b/typst.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unimelb-thesis-template"
-version = "0.2.0"
+version = "0.2.1"
 entrypoint = "lib.typ"
 authors = ["Dylan A Mordaunt"]
 license = "Apache-2.0"
@@ -8,7 +8,7 @@ description = "A modern Typst template for University of Melbourne theses"
 keywords = ["thesis", "university", "melbourne", "academic", "template"]
 categories = ["thesis", "academic"]
 disciplines = ["computer-science", "engineering", "science"]
-repository = "https://github.com/dylanmordaunt/unimelb-thesis-template-typst"
+repository = "https://github.com/edithatogo/unimelb-thesis-template-typst"
 
 [template]
 path = "."


### PR DESCRIPTION
<!-- Describe the purpose of this pull request and link any relevant issue. -->

Summary of changes:

- (short description)

Example PR title/body (copy & paste)

Title: Fix font mapping in utils/style.typ

Body:

- What: Corrected font family mapping to use Fraunces variable font in
  `utils/style.typ`.
- Why: The previous mapping caused fallback fonts to be used on Linux CI.
- Validation: Compiled `sample-chapter.typ` locally and attached `thesis.pdf`.

Checklist for contributors

- [ ] I ran `typst compile thesis.typ`.
- [ ] For chapter/layout changes, I also ran `typst compile sample-chapter.typ` and
  verified the PDF renders as expected.
- [ ] I ran `python scripts/check_packages.py` and addressed any issues it
  reported.
- [ ] For style/layout changes: I attached the generated `thesis.pdf` or a
  screenshot of the affected pages to this PR.
- [ ] I kept changes minimal and documented any edits to fonts, colors, or
  layouts in the PR description.

Notes for reviewers

- Prefer small, incremental PRs for layout or font changes.
  If a change affects many pages, include a brief migration note and a compiled
  `thesis.pdf` snapshot.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released patch version 0.2.1.
  * Updated the project’s repository URL to its new GitHub location, ensuring users can find the latest source, releases, and issue tracking.
  * Metadata refreshed to reflect the new hosting location.
  * No changes to templates or behavior; existing projects continue to work as before.
  * Recommended to update bookmarks and package references to the new repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->